### PR TITLE
detect mixin infinite loop. Issues 160, 239

### DIFF
--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/InfiniteLoopDetector.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/InfiniteLoopDetector.java
@@ -1,0 +1,95 @@
+package com.github.sommeri.less4j.core.compiler.stages;
+
+import java.util.List;
+
+import com.github.sommeri.less4j.core.compiler.scopes.IScope;
+import com.github.sommeri.less4j.core.compiler.scopes.ScopeFactory;
+
+/**
+ * Created by Igor on 15.07.2015.
+ */
+public class InfiniteLoopDetector {
+	private final int DEEP_OF_STACK = 10;
+	private final int MIN_LOOP_COUNT = 3;
+	
+    public void detect(IScope scope) {
+    	scope = getBodyOwnerParent(scope);
+    	int loopCount = detectInfiniteLoop(scope);
+    	if(loopCount >= MIN_LOOP_COUNT) 
+    		throw new RuntimeException("Detected Infinite Loop: " + scope.toFullName());
+    }
+
+	private int detectInfiniteLoop(IScope scope) {
+		int loopCount = 0;
+    	if(scope != null){
+	    	IScope preventInvocation = getPreventInvocation(scope);
+	    	//hasTheSameStack
+	    	boolean hasTheSameStack = hasTheSameStack(scope, preventInvocation);
+	    	if(hasTheSameStack) {
+	    		loopCount = detectInfiniteLoop(preventInvocation) + 1;
+	    	}
+    	}
+		return loopCount;
+	}
+
+	private boolean hasTheSameStack(IScope s1, IScope s2) {
+		int loopsCount = 0;
+		boolean hasTheSameStack = false;
+		do {
+			if(s1 == null || s2 == null
+					|| !isEqualScopes(s1, s2)){
+				break;
+			} else {
+				s1 = getBodyOwnerParent(s1);
+				s2 = getBodyOwnerParent(s2);
+				loopsCount++;
+			}
+			hasTheSameStack = loopsCount >= DEEP_OF_STACK;
+		} while (!hasTheSameStack);
+		return hasTheSameStack;
+	}
+    
+    private IScope getPreventInvocation(IScope scope){
+    	if(!scope.hasParent())
+    		return null;
+    	IScope result = null;
+    	IScope parentScope;
+    	parentScope = scope;
+    	do {
+    		parentScope = getBodyOwnerParent(parentScope);
+    		if (parentScope == null)
+    			break;
+    		if(isEqualScopes(scope, parentScope)){
+    			result = parentScope;
+    			break;
+    		}
+			
+		} while (result == null && parentScope.hasParent());
+    	return result;
+    }
+
+	private IScope getBodyOwnerParent(IScope scope) {
+		if(scope.hasParent()) {
+			IScope parent = scope.getParent();
+			if(ScopeFactory.BODY_OWNER.equals(parent.getType())){
+				return parent;
+			} else {
+				return getBodyOwnerParent(parent);
+			}
+		}
+		return null;
+	}
+
+	private boolean isEqualScopes(IScope s1, IScope s2) {
+		return getScopeSimpleName(s1).equals(getScopeSimpleName(s2));
+	}
+
+	private String getScopeSimpleName(IScope scope) {
+		List<String> names = scope.getNames();
+		if (names != null && !names.isEmpty())
+			return scope.getType() + names;
+		if (ScopeFactory.DEFAULT != scope.getType())
+			return scope.getType() + "[" + scope.getOwner().toString() + "]";
+		return scope.getType();
+	}
+}

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/MixinsRulesetsSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/MixinsRulesetsSolver.java
@@ -34,6 +34,7 @@ class MixinsRulesetsSolver {
   private final Configuration configuration;
   private final DefaultGuardHelper defaultGuardHelper;
   private final CallerCalleeScopeJoiner scopeManipulation = new CallerCalleeScopeJoiner();
+  private final InfiniteLoopDetector infiniteLoopDetector = new InfiniteLoopDetector();
 
   public MixinsRulesetsSolver(ReferencesSolver parentSolver, AstNodesStack semiCompiledNodes, ProblemsHandler problemsHandler, Configuration configuration) {
     this.parentSolver = parentSolver;
@@ -116,7 +117,7 @@ class MixinsRulesetsSolver {
           IScope mixinArguments = buildMixinsArguments(reference, callerScope, fullMixin);
           mixinScope.getParent().add(mixinArguments);
           IScope mixinWorkingScope = scopeManipulation.joinIfIndependent(callerScope, mixinScope);
-
+          infiniteLoopDetector.detect(mixinWorkingScope);
           MixinsGuardsValidator guardsValidator = new MixinsGuardsValidator(mixinWorkingScope, problemsHandler, configuration);
           GuardValue guardValue = guardsValidator.evaluateGuards(mixin);
 

--- a/src/test/java/infiniteloop/InfiniteLoopProtectorTest.java
+++ b/src/test/java/infiniteloop/InfiniteLoopProtectorTest.java
@@ -1,0 +1,28 @@
+package infiniteloop;
+
+import java.io.File;
+
+import com.github.sommeri.less4j.Less4jException;
+import com.github.sommeri.less4j.LessCompiler;
+import com.github.sommeri.less4j.core.ThreadUnsafeLessCompiler;
+import com.github.sommeri.less4j.utils.w3ctestsextractor.common.CaseBuilder;
+
+/**
+ * Created by Igor on 08.07.2015.
+ */
+public class InfiniteLoopProtectorTest extends CaseBuilder {
+    public static void main(String[] args) throws Exception {
+        InfiniteLoopProtectorTest test = new InfiniteLoopProtectorTest();
+        try{
+        	test.compileLess("/testInfiniteLoop.less");
+        } catch (RuntimeException e){
+        	System.out.println(e.getMessage());
+        }
+    }
+
+    public LessCompiler.CompilationResult compileLess(String file) throws Less4jException {
+    	String filePath = getCurrentDirectory() + file;
+        LessCompiler.CompilationResult result = new ThreadUnsafeLessCompiler().compile(new File(filePath));
+        return result;
+    }
+}

--- a/src/test/java/infiniteloop/testInfiniteLoop.less
+++ b/src/test/java/infiniteloop/testInfiniteLoop.less
@@ -1,0 +1,19 @@
+.make-color(){
+	color: red;
+	.make-bold();
+}
+.make-font(){
+	font-size: 20px;
+}
+.make-bold(){
+	font-weight: bold;
+	.make-color();
+}
+.make-all(){
+	.make-bold();
+	.make-font();
+	.make-color();
+}
+body {
+	.make-all();
+}


### PR DESCRIPTION
Hi SomMeri

I propose my variant  of detecting infinite loops in mixins. 
This problem was descibed in issues 160 and 239. 

InfiniteLoopDetector tries to find similar stack trace for current position. 
I added 2 constans: 
DEEP_OF_STACK - number of equal parent elements 
MIN_LOOP_COUNT - number of similar loops

For some projects which generate static css such detector is not required. And I think it could be possible to make it optional through Less Configuration 