### PR TITLE
implemented several performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,18 @@ Less4j is a port. The original compiler was written in JavaScript and is called 
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 		</plugins>
 	</build>
 	<url>https://github.com/SomMeri/less4j</url>

--- a/src/main/java/com/github/sommeri/less4j/LessCompiler.java
+++ b/src/main/java/com/github/sommeri/less4j/LessCompiler.java
@@ -40,6 +40,7 @@ public interface LessCompiler {
     private Map<String, String> externalVariables  = new HashMap<String, String>();
     private EmbeddedScriptGenerator embeddedScriptGenerator;
     private boolean compressing = false;
+    private Cache cache;
 
     /**
      * This is needed in for source map.
@@ -116,6 +117,16 @@ public interface LessCompiler {
     public boolean isCompressing() {
       return compressing;
     }
+    
+	public Cache getCache() {
+	  return cache;
+	}
+
+	public Configuration setCache(Cache cache) {
+	  this.cache = cache;
+	  return this;
+	}
+
   }
 
   public static class SourceMapConfiguration {
@@ -235,6 +246,12 @@ public interface LessCompiler {
 
   }
 
+  public interface Cache {
+	Object get(Object key);
+	void set(Object key, Object value);
+  }
+
+  
   public interface Problem {
 
     public Type getType();

--- a/src/main/java/com/github/sommeri/less4j/LessCompiler.java
+++ b/src/main/java/com/github/sommeri/less4j/LessCompiler.java
@@ -247,8 +247,8 @@ public interface LessCompiler {
   }
 
   public interface Cache {
-	Object get(Object key);
-	void set(Object key, Object value);
+	Object get(LessSource key);
+	void set(LessSource key, Object value);
   }
 
   

--- a/src/main/java/com/github/sommeri/less4j/core/ThreadUnsafeLessCompiler.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ThreadUnsafeLessCompiler.java
@@ -93,12 +93,16 @@ public class ThreadUnsafeLessCompiler implements LessCompiler {
 	StyleSheet lessStyleSheet = null;
 	if (options != null && options.getCache() != null) {
 		lessStyleSheet = (StyleSheet) options.getCache().get(source);
+		if (lessStyleSheet != null) {
+			lessStyleSheet = lessStyleSheet.clone(); // need to leave cached version unchanged
+		}
 	}
 	if (lessStyleSheet == null) {
 		ParseResult result = toAntlrTree(source);
 		lessStyleSheet = astBuilder.parseStyleSheet(result.getTree());
 		if (options != null && options.getCache() != null) {
 			options.getCache().set(source, lessStyleSheet);
+			lessStyleSheet = lessStyleSheet.clone(); // need to leave cached version unchanged
 		}
 	}
 

--- a/src/main/java/com/github/sommeri/less4j/core/ThreadUnsafeLessCompiler.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ThreadUnsafeLessCompiler.java
@@ -90,8 +90,17 @@ public class ThreadUnsafeLessCompiler implements LessCompiler {
   }
 
   private CompilationResult doCompile(LessSource source, Configuration options) throws Less4jException {
-    ParseResult result = toAntlrTree(source);
-    StyleSheet lessStyleSheet = astBuilder.parseStyleSheet(result.getTree());
+	StyleSheet lessStyleSheet = null;
+	if (options != null && options.getCache() != null) {
+		lessStyleSheet = (StyleSheet) options.getCache().get(source);
+	}
+	if (lessStyleSheet == null) {
+		ParseResult result = toAntlrTree(source);
+		lessStyleSheet = astBuilder.parseStyleSheet(result.getTree());
+		if (options != null && options.getCache() != null) {
+			options.getCache().set(source, lessStyleSheet);
+		}
+	}
 
     Map<String, HiddenTokenAwareTree> variables = toAntlrTree(options.getVariables());
     List<VariableDeclaration> externalVariables = astBuilder.parseVariables(variables);

--- a/src/main/java/com/github/sommeri/less4j/core/ast/CssClass.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ast/CssClass.java
@@ -9,6 +9,9 @@ import com.github.sommeri.less4j.utils.ArraysUtils;
 public class CssClass extends ElementSubsequent {
 
   private InterpolableName name;
+  private String cachedName;
+  private String cachedFullName;
+
 
   public CssClass(HiddenTokenAwareTree token, InterpolableName name) {
     super(token);
@@ -16,11 +19,25 @@ public class CssClass extends ElementSubsequent {
   }
 
   public String getName() {
-    return name.getName();
+	if (cachedName != null) {
+		return cachedName;
+	}
+    String result = name.getName();
+    if (!isInterpolated()) {
+    	cachedName = result;
+    }
+    return result;
   }
 
   public String getFullName() {
-    return "." + getName();
+	if (cachedFullName != null) {
+	  return cachedFullName;
+	}
+    String result = "." + getName();
+    if (!isInterpolated()) {
+    	cachedFullName = result;
+    }
+    return result;
   }
 
   @Override
@@ -31,6 +48,8 @@ public class CssClass extends ElementSubsequent {
   @Override
   public void extendName(String extension) {
     name.extendName(extension);
+    cachedName = null;
+    cachedFullName = null;
   }
   
   @Override

--- a/src/main/java/com/github/sommeri/less4j/core/ast/Declaration.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ast/Declaration.java
@@ -65,11 +65,13 @@ public class Declaration extends ASTCssNode {
   }
 
   public boolean isFontDeclaration() {
-    return getNameAsString()!=null? getNameAsString().toLowerCase().equals("font") : false;
+	String n = getNameAsString();
+    return n!=null ? n.toLowerCase().equals("font") : false;
   }
 
   public boolean isFilterDeclaration() {
-    return getNameAsString()!=null? getNameAsString().toLowerCase().endsWith("filter") : false;
+	String n = getNameAsString();
+    return n!=null ? n.toLowerCase().endsWith("filter") : false;
   }
   
   @Override

--- a/src/main/java/com/github/sommeri/less4j/core/ast/IdSelector.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ast/IdSelector.java
@@ -9,6 +9,8 @@ import com.github.sommeri.less4j.utils.ArraysUtils;
 public class IdSelector extends ElementSubsequent {
 
   private InterpolableName name;
+  private String cachedName;
+  private String cachedFullName;
 
   public IdSelector(HiddenTokenAwareTree token, InterpolableName name) {
     super(token);
@@ -16,11 +18,25 @@ public class IdSelector extends ElementSubsequent {
   }
 
   public String getName() {
-    return name.getName();
+	if (cachedName != null) {
+		return cachedName;
+	}
+    String result = name.getName();
+    if (!isInterpolated()) {
+    	cachedName = result;
+    }
+    return result;
   }
 
   public String getFullName() {
-    return "#" + getName();
+	if (cachedFullName != null) {
+	  return cachedFullName;
+	}
+    String result = "#" + getName();
+    if (!isInterpolated()) {
+    	cachedFullName = result;
+    }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/github/sommeri/less4j/core/ast/Selector.java
+++ b/src/main/java/com/github/sommeri/less4j/core/ast/Selector.java
@@ -67,7 +67,8 @@ public class Selector extends ASTCssNode implements Cloneable {
   @Override
   @NotAstProperty
   public List<? extends ASTCssNode> getChilds() {
-    ArrayList<ASTCssNode> result = new ArrayList<ASTCssNode>(combinedParts);
+    ArrayList<ASTCssNode> result = new ArrayList<ASTCssNode>(combinedParts.size() + extend.size());
+    result.addAll(combinedParts);
     result.addAll(extend);
     return result;
   }

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/LessToCssCompiler.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/LessToCssCompiler.java
@@ -161,10 +161,9 @@ public class LessToCssCompiler {
 
   private void evaluateExpressions(ASTCssNode node) {
     ASTManipulator manipulator = new ASTManipulator();
-    //variables are not supposed to be there now
-    ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(problemsHandler, configuration);
-
     if (node instanceof Expression) {
+      //variables are not supposed to be there now
+      ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(problemsHandler, configuration);
       Expression value = expressionEvaluator.evaluate((Expression) node);
       manipulator.replace(node, value);
     } else {
@@ -183,7 +182,6 @@ public class LessToCssCompiler {
           evaluateExpressions(kid);
           break;
         }
-
       }
     }
   }

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/expressions/ExpressionEvaluator.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/expressions/ExpressionEvaluator.java
@@ -55,7 +55,7 @@ public class ExpressionEvaluator {
   private ArithmeticCalculator arithmeticCalculator;
   private ColorsCalculator colorsCalculator;
   private ExpressionComparator comparator = new GuardsComparator();
-  private List<FunctionsPackage> functions = new ArrayList<FunctionsPackage>();
+  private List<FunctionsPackage> functions = new ArrayList<FunctionsPackage>(10);
   private StringInterpolator stringInterpolator;
   private StringInterpolator embeddedScriptInterpolator;
   private EmbeddedScriptGenerator embeddedScripting;

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/scopes/view/ScopesTreeView.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/scopes/view/ScopesTreeView.java
@@ -1,9 +1,7 @@
 package com.github.sommeri.less4j.core.compiler.scopes.view;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.github.sommeri.less4j.core.compiler.scopes.AbstractScopesTree;
 import com.github.sommeri.less4j.core.compiler.scopes.IScope;
@@ -19,7 +17,8 @@ public class ScopesTreeView extends AbstractScopesTree {
   
   private ScopeView publicParent;
   private List<IScope> publicChilds = null;
-  private Map<IScope, ScopeView> fakeChildsMap = new HashMap<IScope, ScopeView>();
+  private IScope fakeChildScope;
+  private ScopeView fakeChildScopeView;
 
   public ScopesTreeView(IScopesTree originalStructure, IScope joinToParentTree, ScopeView publicParent, ScopeView publicChild) {
     super();
@@ -27,8 +26,10 @@ public class ScopesTreeView extends AbstractScopesTree {
     this.joinToParentTree = joinToParentTree;
     this.publicParent = publicParent;
 
-    if (publicChild!=null)
-      this.fakeChildsMap.put(publicChild.getUnderlying(), publicChild);
+    if (publicChild!=null) {
+    	fakeChildScope = publicChild.getUnderlying();
+    	fakeChildScopeView = publicChild;
+    }
   }
 
   public void setScope(ScopeView scope) {
@@ -70,8 +71,8 @@ public class ScopesTreeView extends AbstractScopesTree {
 
     List<IScope> result = new ArrayList<IScope>();
     for (IScope childScope : realChilds) {
-      if (fakeChildsMap.containsKey(childScope)) {
-        result.add(fakeChildsMap.get(childScope));
+      if (fakeChildScope != null && fakeChildScope.equals(childScope)) {
+        result.add(fakeChildScopeView);
       } else {
         result.add(ScopeFactory.createChildScopeView(childScope, scope, joinToParentTree));
       }

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/selectors/ExtendsSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/selectors/ExtendsSolver.java
@@ -42,17 +42,36 @@ public class ExtendsSolver {
   }
 
   private void solveInlineExtends(Selector extendingSelector) {
+	ArrayList<ExtendRefs> doExtends = null;
     for (RuleSet ruleSet : allRulesets) {
-      List<Selector> selectors = new ArrayList<Selector>(ruleSet.getSelectors());
-      for (Selector targetSelector : selectors) {
+      for (Selector targetSelector : ruleSet.getSelectors()) {
         Selector newSelector = constructNewSelector(extendingSelector, targetSelector);
         if (newSelector!=null && canExtend(extendingSelector, newSelector, ruleSet)) {
-          doTheExtend(extendingSelector, newSelector, ruleSet, targetSelector);
+            if (doExtends == null) {
+          	  doExtends = new ArrayList<ExtendRefs>();
+            }
+            doExtends.add(new ExtendRefs(ruleSet, targetSelector, newSelector));          
         }
       }
-
+    }
+    if (doExtends != null) {
+      for (ExtendRefs refs : doExtends) {
+        doTheExtend(extendingSelector, refs.newSelector, refs.ruleSet, refs.targetSelector);
+      }
     }
   }
+  
+  private static class ExtendRefs {
+	ExtendRefs(RuleSet ruleSet, Selector targetSelector, Selector newSelector) {
+      this.ruleSet = ruleSet;
+	  this.targetSelector = targetSelector;
+	  this.newSelector = newSelector;
+	}
+	RuleSet ruleSet;
+	Selector targetSelector;
+	Selector newSelector;
+  }
+
 
   private void doTheExtend(Selector extendingSelector, Selector newSelector, RuleSet ruleSet, Selector targetSelector) {
     addSelector(ruleSet, newSelector);

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/ASTManipulator.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/ASTManipulator.java
@@ -2,6 +2,7 @@ package com.github.sommeri.less4j.core.compiler.stages;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -72,7 +73,8 @@ public class ASTManipulator {
   }
 
   private boolean isAstProperty(PropertyDescriptor descriptor) {
-    return descriptor.getReadMethod()!=null && !descriptor.getReadMethod().isAnnotationPresent(NotAstProperty.class);
+	Method rm = descriptor.getReadMethod();
+    return rm!=null && !rm.isAnnotationPresent(NotAstProperty.class);
   }
 
   private boolean isList(Class<?> propertyType) {
@@ -89,8 +91,8 @@ public class ASTManipulator {
   }
 
   private void replaceInProperty(PropertyDescriptor propertyDescriptor, ASTCssNode parent, ASTCssNode oldChild, ASTCssNode newChild) {
-    setPropertyValue(newChild, parent, "parent");
-    setPropertyValue(oldChild, null, "parent");
+	newChild.setParent(parent);
+	oldChild.setParent(null);
     setPropertyValue(parent, newChild, propertyDescriptor);
   }
 
@@ -162,16 +164,7 @@ public class ASTManipulator {
   }
 
   private void setPropertyValue(ASTCssNode parent, ASTCssNode value, PropertyDescriptor descriptor) {
-    try {
-      PropertyUtils.setProperty(parent, descriptor.getName(), value);
-    } catch (IllegalAccessException e) {
-      throw new BugHappened(e, value);
-    } catch (InvocationTargetException e) {
-      throw new BugHappened(e, value);
-    } catch (NoSuchMethodException e) {
-      throw new BugHappened(e, value);
-    }
-
+    setPropertyValue(parent, value, descriptor.getName());
   }
 
   private Object getPropertyValue(ASTCssNode object, PropertyDescriptor descriptor) {

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/EmptyBodiesRemover.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/EmptyBodiesRemover.java
@@ -22,8 +22,10 @@ public class EmptyBodiesRemover {
         ownerlessComments.addAll(kid.getTrailingComments());
         manipulator.removeFromBody(kid);
       } else {
-        manipulator.addOpeningComments(kid, ownerlessComments);
-        ownerlessComments = new ArrayList<Comment>();
+    	if (!ownerlessComments.isEmpty()) {
+    		manipulator.addOpeningComments(kid, ownerlessComments);
+    		ownerlessComments = new ArrayList<Comment>();
+    	}
       }
     }
   }

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/MixinsRulesetsSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/MixinsRulesetsSolver.java
@@ -55,7 +55,6 @@ class MixinsRulesetsSolver {
   }
 
   private Couple<List<ASTCssNode>, IScope> resolveCalledBody(final IScope callerScope, final BodyOwner<?> bodyOwner, final IScope referencedMixinScope, final ReturnMode returnMode) {
-    final ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(referencedMixinScope, problemsHandler, configuration);
 
     // ... and I'm starting to see the point of closures ...
     return InScopeSnapshotRunner.runInLocalDataSnapshot(referencedMixinScope, new IFunction<Couple<List<ASTCssNode>, IScope>>() {
@@ -68,6 +67,7 @@ class MixinsRulesetsSolver {
         // collect variables and mixins to be imported
         IScope returnValues = ScopeFactory.createDummyScope();
         if (returnMode == ReturnMode.MIXINS_AND_VARIABLES) {
+          ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(referencedMixinScope, problemsHandler, configuration);
           returnValues.addFilteredVariables(new ImportedScopeFilter(expressionEvaluator, callerScope), referencedMixinScope);
         }
         List<FullMixinDefinition> unmodifiedMixinsToImport = referencedMixinScope.getAllMixins();

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/ReferencesSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/ReferencesSolver.java
@@ -163,11 +163,13 @@ public class ReferencesSolver {
 
   private Map<ASTCssNode, GeneralBody> solveCalls(List<ASTCssNode> childs, IScope referenceScope) {
     Map<ASTCssNode, GeneralBody> solvedMixinReferences = new HashMap<ASTCssNode, GeneralBody>();
-    ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(referenceScope, problemsHandler, configuration);
+    ExpressionEvaluator expressionEvaluator = null;
     for (ASTCssNode kid : childs) {
       if (isMixinReference(kid)) {
         MixinReference reference = (MixinReference) kid;
-
+        if (expressionEvaluator == null) {
+        	expressionEvaluator = new ExpressionEvaluator(referenceScope, problemsHandler, configuration);
+        }
         EvaluatedMixinReferenceCall evaluatedMixinReference = new EvaluatedMixinReferenceCall(reference, expressionEvaluator);
         List<FoundMixin> foundMixins = findReferencedMixins(evaluatedMixinReference, referenceScope);
         GeneralBody replacement = mixinsSolver.buildMixinReferenceReplacement(evaluatedMixinReference, referenceScope, foundMixins);
@@ -181,6 +183,9 @@ public class ReferencesSolver {
         if (fullNodeDefinition == null) {
           handleUnavailableDetachedRulesetReference(detachedRulesetReference, solvedMixinReferences);
         } else {
+          if (expressionEvaluator == null) {
+        	  expressionEvaluator = new ExpressionEvaluator(referenceScope, problemsHandler, configuration);
+          }
           Expression evaluatedDetachedRuleset = expressionEvaluator.evaluate(fullNodeDefinition);
           fullNodeDefinition = evaluatedDetachedRuleset;
           if (evaluatedDetachedRuleset.getType() != ASTCssNodeType.DETACHED_RULESET) {
@@ -199,7 +204,7 @@ public class ReferencesSolver {
     }
     return solvedMixinReferences;
   }
-
+  
   private void handleUnavailableDetachedRulesetReference(DetachedRulesetReference detachedRulesetReference, Map<ASTCssNode, GeneralBody> solvedReferences) {
     problemsHandler.detachedRulesetNotfound(detachedRulesetReference);
     GeneralBody errorBody = new GeneralBody(detachedRulesetReference.getUnderlyingStructure());

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/SingleImportSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/SingleImportSolver.java
@@ -3,9 +3,9 @@ package com.github.sommeri.less4j.core.compiler.stages;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
+import com.github.sommeri.less4j.LessCompiler.Cache;
 import com.github.sommeri.less4j.LessCompiler.Configuration;
 import com.github.sommeri.less4j.LessSource;
 import com.github.sommeri.less4j.LessSource.CannotReadFile;
@@ -32,11 +32,25 @@ public class SingleImportSolver {
   private TypesConversionUtils conversionUtils = new TypesConversionUtils();
   private ASTManipulator astManipulator = new ASTManipulator();
 
-  private Map<LessSource, StyleSheet> astCache = new HashMap<LessSource, StyleSheet>();
+  private Cache astCache;
   
   public SingleImportSolver(ProblemsHandler problemsHandler, Configuration configuration) {
     this.problemsHandler = problemsHandler;
     this.configuration = configuration;
+    this.astCache = configuration.getCache();
+    if (astCache == null) {  
+    	final HashMap<Object, Object> map = new HashMap<Object, Object>();
+    	astCache = new Cache() {
+			@Override
+			public Object get(Object key) {
+				return map.get(key);
+			}
+			@Override
+			public void set(Object key, Object value) {
+				map.put(key, value);		
+			}    		
+    	};
+    }
   }
 
   public ASTCssNode importEncountered(Import node, LessSource source, AlreadyImportedSources alreadyImportedSources) {
@@ -143,15 +157,12 @@ public class SingleImportSolver {
   }
 
   private StyleSheet getImportedAst(Import node, LessSource source, String content) {
-    if (astCache.containsKey(source)) {
-      return astCache.get(source).clone();
-    }
-
-    // parse imported file
-    StyleSheet importedAst = parseContent(node, content, source);
-    
-    astCache.put(source, importedAst.clone());
-    return importedAst;
+	StyleSheet importedAst = (StyleSheet) astCache.get(source);
+	if (importedAst == null) {
+	  importedAst = parseContent(node, content, source);
+	  astCache.set(source, importedAst);
+	}
+	return importedAst.clone();
   }
 
   private StyleSheet parseContent(Import importNode, String importedContent, LessSource source) {

--- a/src/main/java/com/github/sommeri/less4j/core/compiler/stages/SingleImportSolver.java
+++ b/src/main/java/com/github/sommeri/less4j/core/compiler/stages/SingleImportSolver.java
@@ -42,11 +42,11 @@ public class SingleImportSolver {
     	final HashMap<Object, Object> map = new HashMap<Object, Object>();
     	astCache = new Cache() {
 			@Override
-			public Object get(Object key) {
+			public Object get(LessSource key) {
 				return map.get(key);
 			}
 			@Override
-			public void set(Object key, Object value) {
+			public void set(LessSource key, Object value) {
 				map.put(key, value);		
 			}    		
     	};

--- a/src/main/java/com/github/sommeri/less4j/core/validators/CssAstValidator.java
+++ b/src/main/java/com/github/sommeri/less4j/core/validators/CssAstValidator.java
@@ -1,7 +1,5 @@
 package com.github.sommeri.less4j.core.validators;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import com.github.sommeri.less4j.core.ast.ASTCssNode;
@@ -22,8 +20,8 @@ public class CssAstValidator {
     if (node instanceof Body)
       validateBody((Body)node);
     
-    List<ASTCssNode> childs = new ArrayList<ASTCssNode>(node.getChilds());
-    for (ASTCssNode kid : childs) {
+    // no need to copy the array for validation?
+    for (ASTCssNode kid : node.getChilds()) {
       validate(kid);
     }
 

--- a/src/main/java/com/github/sommeri/less4j/core/validators/SupportedLessBodyMembers.java
+++ b/src/main/java/com/github/sommeri/less4j/core/validators/SupportedLessBodyMembers.java
@@ -1,8 +1,7 @@
 package com.github.sommeri.less4j.core.validators;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 import com.github.sommeri.less4j.core.ast.ASTCssNodeType;
@@ -11,13 +10,21 @@ import com.github.sommeri.less4j.core.ast.Body;
 //this check is that important, the allowed css types check can be
 public class SupportedLessBodyMembers {
 
-  private static final Set<ASTCssNodeType> KEYFRAMES_SUPPORTED_MEMBERS = new HashSet<ASTCssNodeType>();
+  private static final EnumSet<ASTCssNodeType> KEYFRAMES_SUPPORTED_MEMBERS;
+  private static final EnumSet<ASTCssNodeType> ALL_NODE_TYPES; 
+  private static final EnumSet<ASTCssNodeType> STYLE_SHEET_SUPPORTED_MEMBERS;
 
   static {
-    KEYFRAMES_SUPPORTED_MEMBERS.add(ASTCssNodeType.RULE_SET);
-    KEYFRAMES_SUPPORTED_MEMBERS.add(ASTCssNodeType.MIXIN_REFERENCE);
-    KEYFRAMES_SUPPORTED_MEMBERS.add(ASTCssNodeType.REUSABLE_STRUCTURE);
-    KEYFRAMES_SUPPORTED_MEMBERS.add(ASTCssNodeType.VARIABLE_DECLARATION);
+	KEYFRAMES_SUPPORTED_MEMBERS  = EnumSet.of(ASTCssNodeType.RULE_SET,
+			                                  ASTCssNodeType.MIXIN_REFERENCE,
+			                                  ASTCssNodeType.REUSABLE_STRUCTURE,
+			                                  ASTCssNodeType.VARIABLE_DECLARATION);
+    
+    ALL_NODE_TYPES = EnumSet.allOf(ASTCssNodeType.class);
+
+    STYLE_SHEET_SUPPORTED_MEMBERS = EnumSet.allOf(ASTCssNodeType.class);
+    STYLE_SHEET_SUPPORTED_MEMBERS.remove(ASTCssNodeType.DECLARATION);
+    STYLE_SHEET_SUPPORTED_MEMBERS.remove(ASTCssNodeType.PAGE_MARGIN_BOX);
   }
 
   public Set<ASTCssNodeType> getSupportedMembers(Body node) {
@@ -31,11 +38,7 @@ public class SupportedLessBodyMembers {
     //special case - style sheet does not have owner 
     switch (bodyType) {
     case STYLE_SHEET:
-      Set<ASTCssNodeType> result = allNodeTypes();
-      // removed only the elements that are likely to end there, this method could be done in more precise way  
-      result.remove(ASTCssNodeType.DECLARATION);
-      result.remove(ASTCssNodeType.PAGE_MARGIN_BOX);
-      return result;
+      return Collections.unmodifiableSet(STYLE_SHEET_SUPPORTED_MEMBERS);
 
     default:
       //nothing is needed
@@ -58,7 +61,7 @@ public class SupportedLessBodyMembers {
   }
 
   private Set<ASTCssNodeType> allNodeTypes() {
-    return new HashSet<ASTCssNodeType>(Arrays.asList(ASTCssNodeType.values()));
+    return Collections.unmodifiableSet(ALL_NODE_TYPES);
   }
 
 }

--- a/src/main/java/com/github/sommeri/less4j/utils/ListsComparator.java
+++ b/src/main/java/com/github/sommeri/less4j/utils/ListsComparator.java
@@ -1,41 +1,39 @@
 package com.github.sommeri.less4j.utils;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class ListsComparator {
 
   public <T> boolean equals(List<T> first, List<T> second, ListMemberComparator<T> comparator) {
-    if (first.size() != second.size())
+    if (first.size() != second.size()) {
       return false;
-
-    Iterator<T> i1 = first.iterator();
-    Iterator<T> i2 = second.iterator();
-    while (i1.hasNext()) {
-      T firstMember = i1.next();
-      T secondMember = i2.next();
-      if (!comparator.equals(firstMember, secondMember))
-        return false;
-    }
-    return true;
+	}
+    return equals(first, second, first.size(), comparator);
+  }
+		  
+  public <T> boolean equals(List<T> first, List<T> second, int count, ListMemberComparator<T> comparator) {
+    for (int i = 0; i < first.size() && i < count; i++) {
+	  if (!comparator.equals(first.get(i), second.get(i))) {
+	    return false;
+	  }
+	}
+	return true;
   }
 
   public <T> boolean prefix(List<T> lookFor, List<T> inList, ListMemberComparator<T> comparator) {
     if (lookFor.isEmpty())
-      return true;
+	  return true;
 
-    if (lookFor.size() > inList.size())
-      return false;
+	if (lookFor.size() > inList.size())
+	  return false;
+	
+	int beforeLast = lookFor.size() - 1;
 
-    List<T> relevantInList = ArraysUtils.sameLengthPrefix(inList, lookFor);
-    List<T> relevantInListWithoutLast = ArraysUtils.sublistWithoutLast(relevantInList);
-    List<T> lookForWithoutLast = ArraysUtils.sublistWithoutLast(lookFor);
+	if (!equals(lookFor, inList, beforeLast, comparator))
+	  return false;
 
-    if (!equals(lookForWithoutLast, relevantInListWithoutLast, comparator))
-      return false;
-
-    return comparator.prefix(ArraysUtils.last(lookFor), ArraysUtils.last(relevantInList));
+	return comparator.prefix(lookFor.get(beforeLast), inList.get(beforeLast));
   }
 
   public <T> MatchMarker<T> prefixMatches(List<T> lookFor, List<T> inList, ListMemberComparator<T> comparator) {


### PR DESCRIPTION
This branch incorporates several performance improvements. I filed some of the as separate issues recently. In our large projects these changes provide approximately 3x-4x  speed-up.

Included here:

1. Externalizing AST cache, so that it can be reused across compile calls
2. Copy on write functionality for LocalScope to avoid unnecessary clone() calls
3. Caching of CssClass names so that it's not recomputed needlessly in comparators
4. ListsComparator optimization to increase speed  and decrease garbage creation
5. ExtendsSolver optimization to not create ArrayLists when not needed
6. ScopesTreeView does not create HashMap any more
7. Added source jar generation in POM.xml. Makes it easier for me to setup ivy dependencies in my project. 