### PR TITLE
Replace org.json with gson (fixes #326)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@ Less4j is a port. The original compiler was written in JavaScript and is called 
 		</dependency>
 		<!-- There are needed for source map, should be moved to separate project -->
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20090211</version>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/github/sommeri/sourcemap/SourceMapConsumerFactory.java
+++ b/src/main/java/com/github/sommeri/sourcemap/SourceMapConsumerFactory.java
@@ -16,8 +16,9 @@
 
 package com.github.sommeri.sourcemap;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 
 /**
  * Detect and parse the provided source map.
@@ -59,9 +60,9 @@ public class SourceMapConsumerFactory {
     if (contents.startsWith("{")) {
       try {
         // Revision 2 and 3, are JSON Objects
-        JSONObject sourceMapRoot = new JSONObject(contents);
+        JsonObject sourceMapRoot = new JsonParser().parse(contents).getAsJsonObject();
         // Check basic assertions about the format.
-        int version = sourceMapRoot.getInt("version");
+        int version = sourceMapRoot.get("version").getAsInt();
         switch (version) {
         case 3: {
           SourceMapConsumerV3 consumer = new SourceMapConsumerV3();
@@ -71,7 +72,7 @@ public class SourceMapConsumerFactory {
         default:
           throw new SourceMapParseException("Unknown source map version:" + version);
         }
-      } catch (JSONException ex) {
+      } catch (JsonParseException ex) {
         throw new SourceMapParseException("JSON parse exception: " + ex);
       }
     }

--- a/src/test/java/com/github/sommeri/less4j/utils/JSONUtils.java
+++ b/src/test/java/com/github/sommeri/less4j/utils/JSONUtils.java
@@ -3,30 +3,29 @@ package com.github.sommeri.less4j.utils;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 public class JSONUtils {
 
-  public static String getString(JSONObject object, String propertyName) throws JSONException {
+  public static String getString(JsonObject object, String propertyName) {
     if (object.has(propertyName))
-      return object.getString(propertyName);
+      return object.get(propertyName).getAsString();
 
     return null;
   }
 
-  public static List<String> getStringList(JSONObject object, String propertyName) throws JSONException {
+  public static List<String> getStringList(JsonObject object, String propertyName) {
     if (object.has(propertyName))
-      return toStringList(object.getJSONArray(propertyName));
+      return toStringList(object.get(propertyName).getAsJsonArray());
 
     return null;
   }
 
-  public static List<String> toStringList(JSONArray jsonArray) throws JSONException {
+  public static List<String> toStringList(JsonArray jsonArray) {
     List<String> result = new ArrayList<String>();
-    for (int i = 0; i < jsonArray.length(); i++) {
-      result.add(jsonArray.isNull(i) ? null : jsonArray.getString(i));
+    for (int i = 0; i < jsonArray.size(); i++) {
+      result.add(jsonArray.get(i).isJsonNull() ? null : jsonArray.get(i).getAsString());
     }
     return result;
   }

--- a/src/test/java/com/github/sommeri/less4j/utils/SourceMapValidator.java
+++ b/src/test/java/com/github/sommeri/less4j/utils/SourceMapValidator.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
-import org.json.JSONObject;
-import org.json.JSONTokener;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import com.github.sommeri.less4j.LessCompiler.CompilationResult;
 import com.github.sommeri.sourcemap.FilePosition;
@@ -129,8 +129,8 @@ public class SourceMapValidator {
       return new Mapdata();
 
     try {
-      JSONTokener tokener = new JSONTokener(new InputStreamReader(new FileInputStream(mapdataFile), "utf-8"));
-      JSONObject mapdata = new JSONObject(tokener);
+      JsonParser parser = new JsonParser();
+      JsonObject mapdata = parser.parse(new InputStreamReader(new FileInputStream(mapdataFile), "utf-8")).getAsJsonObject();
 
       List<String> expectedSources = JSONUtils.getStringList(mapdata, SOURCES_PROPERTY);
       List<String> expectedSourcesContent = JSONUtils.getStringList(mapdata, SOURCES_CEONTENT_PROPERTY);

--- a/src/test/resources/command-line/one.mapdata
+++ b/src/test/resources/command-line/one.mapdata
@@ -1,4 +1,4 @@
 {
 "file":"oneNew.css",
-"sources":["one.less"],
+"sources":["one.less"]
 }

--- a/src/test/resources/source-map/content/sm-add-unmappable-files.mapdata
+++ b/src/test/resources/source-map/content/sm-add-unmappable-files.mapdata
@@ -1,3 +1,3 @@
 {
-"sources":["sm-add-unmappable-files.less", "import/no-mappable-symbol.less"],
+"sources":["sm-add-unmappable-files.less", "import/no-mappable-symbol.less"]
 }


### PR DESCRIPTION
Avoids the no-evil clause of the org.json license. See discussion in #326.